### PR TITLE
vlc-android repository has been moved to a new one

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ project.ext.vlcAndroidSource = file('vlc-android')
 project.ext.vlcSource = file('vlc-android/vlc')
 
 task cloneVlcAndroid << {
-    Grgit.clone(uri: 'http://git.videolan.org/git/vlc-ports/android.git',
+    Grgit.clone(uri: 'https://code.videolan.org/videolan/vlc-android.git',
             dir: project.ext.vlcAndroidSource)
 }
 


### PR DESCRIPTION
http://git.videolan.org/git/vlc-ports/android.git has been moved to https://code.videolan.org/videolan/vlc-android.git

This was causing Failure of cloneVlcAndroid task